### PR TITLE
BundleInstall -> PluginInstall

### DIFF
--- a/hooks/post-up/vundle.sh
+++ b/hooks/post-up/vundle.sh
@@ -3,4 +3,4 @@
 if [ ! -e $HOME/.vim/bundle/vundle ]; then
   git clone https://github.com/gmarik/vundle.git $HOME/.vim/bundle/vundle
 fi
-vim -u $HOME/.vimrc.bundles +BundleInstall +qa
+vim -u $HOME/.vimrc.bundles +PluginInstall +qa


### PR DESCRIPTION
As of [gmarik/vundle#bf70a158c5db74b5c1415713976d41943788d0d1](https://github.com/gmarik/Vundle.vim/commit/bf70a158c5db74b5c1415713976d41943788d0d1) it now uses Plugin in place of Bundle.
